### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
   },
   "readmeFilename": "readme.md",
   "author": "Tamer Aydin",
-  "license": {
-    "type": "MIT",
-    "url": "http://tameraydin.mit-license.org/"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/tameraydin/react-hot-component.git"


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)
